### PR TITLE
Update linux_name_checker.py

### DIFF
--- a/linux_name_checker.py
+++ b/linux_name_checker.py
@@ -86,4 +86,5 @@ def build_desktop_file(list_to_check):
 
 
 #start the program
-start()
+if __name__ == "__main__":
+    start()


### PR DESCRIPTION
Added the `__name__ == "__main__"` guard. This keeps `start()` from executing when the file is imported and is a very common idiom for python code. For instance, if you were debugging in a python read/execute/print loop (repl) you could import your file and it would not immediately try to run `start`.  Another example would be writing another tool that wants to take advantage of the capabilities of this module but doesn't necessarily work on directories.